### PR TITLE
review: All features 2026-03-24 — Graph v3, Agent IDE, Context Inspector v2, Notion

### DIFF
--- a/server/routes/connectors/index.ts
+++ b/server/routes/connectors/index.ts
@@ -17,6 +17,7 @@ import googleSheetsRoutes from './google-sheets.js';
 import gmailRoutes from './gmail.js';
 import googleDriveRoutes from './google-drive.js';
 // Extra
+import notionRoutes from './notion.js';
 import planeRoutes from './plane.js';
 
 const router = Router();
@@ -35,6 +36,7 @@ router.use('/google-sheets', googleSheetsRoutes);
 router.use('/gmail', gmailRoutes);
 router.use('/google-drive', googleDriveRoutes);
 // Extra
+router.use('/notion', notionRoutes);
 router.use('/plane', planeRoutes);
 
 export default router;

--- a/server/routes/connectors/notion.ts
+++ b/server/routes/connectors/notion.ts
@@ -1,0 +1,192 @@
+/**
+ * Notion Connector (v2) — delegates to the main connectors.ts Notion endpoints.
+ *
+ * The full Notion implementation (test, fetch, search, OAuth) lives in
+ * server/routes/connectors.ts. This v2 route file re-exports the same
+ * functionality so the frontend can access it via /api/connectors/v2/notion/*.
+ */
+
+import { Router } from 'express';
+import { connectorError, getApiKey } from './shared.js';
+
+const router = Router();
+const sessionKeys = new Map<string, string>();
+
+const NOTION_API = 'https://api.notion.com/v1';
+
+function notionHeaders(key: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${key}`,
+    'Notion-Version': '2022-06-28',
+    'Content-Type': 'application/json',
+  };
+}
+
+// ── Test ──
+
+router.post('/test', async (req, res) => {
+  const { apiKey } = req.body as { apiKey?: string };
+  if (!apiKey) { res.status(400).json({ status: 'error', error: 'Missing apiKey' }); return; }
+
+  try {
+    const resp = await fetch(`${NOTION_API}/users/me`, { headers: notionHeaders(apiKey) });
+    if (resp.status === 401) {
+      res.status(401).json({ status: 'error', error: 'Invalid Notion API key. Create one at notion.so/my-integrations' });
+      return;
+    }
+    if (!resp.ok) {
+      res.status(resp.status).json({ status: 'error', error: `Notion API error: ${resp.status}` });
+      return;
+    }
+    const user = await resp.json() as { id: string; name?: string };
+    sessionKeys.set('notion', apiKey);
+    res.json({ status: 'ok', data: { user: user.name ?? user.id } });
+  } catch (err) { connectorError(res, 'Notion', err); }
+});
+
+// ── Search ──
+
+router.post('/search', async (req, res) => {
+  const apiKey = getApiKey(req, sessionKeys, 'notion');
+  if (!apiKey) { res.status(401).json({ status: 'error', error: 'No API key. Test connection first.' }); return; }
+
+  const { query } = req.body as { query?: string };
+  try {
+    const resp = await fetch(`${NOTION_API}/search`, {
+      method: 'POST',
+      headers: notionHeaders(apiKey),
+      body: JSON.stringify(query ? { query, page_size: 20 } : { page_size: 20 }),
+    });
+    if (!resp.ok) {
+      res.status(resp.status).json({ status: 'error', error: `Notion search failed: ${resp.status}` });
+      return;
+    }
+    const data = await resp.json() as { results: Array<{ id: string; object: string; properties?: Record<string, any>; title?: Array<{ plain_text: string }> }> };
+    const results = data.results.map(r => {
+      let title = r.id;
+      if (r.object === 'database' && r.title?.[0]) {
+        title = r.title[0].plain_text;
+      } else if (r.properties) {
+        const titleProp = Object.values(r.properties).find((p: any) => p.type === 'title');
+        title = (titleProp as any)?.title?.[0]?.plain_text ?? r.id;
+      }
+      return { id: r.id, title, type: r.object };
+    });
+    res.json({ status: 'ok', data: results });
+  } catch (err) { connectorError(res, 'Notion', err); }
+});
+
+// ── Fetch page content ──
+
+router.post('/fetch', async (req, res) => {
+  const apiKey = getApiKey(req, sessionKeys, 'notion');
+  if (!apiKey) { res.status(401).json({ status: 'error', error: 'No API key. Test connection first.' }); return; }
+
+  const { pageIds, databaseIds } = req.body as { pageIds?: string[]; databaseIds?: string[] };
+  try {
+    const items: Array<{ id: string; title: string; content: string; tokens: number }> = [];
+
+    for (const pageId of pageIds ?? []) {
+      const page = await fetchNotionPage(pageId, apiKey);
+      if (page) items.push(page);
+    }
+
+    for (const dbId of databaseIds ?? []) {
+      const rows = await queryNotionDatabase(dbId, apiKey);
+      items.push(...rows);
+    }
+
+    // If nothing specified, search recent pages
+    if (!pageIds?.length && !databaseIds?.length) {
+      const resp = await fetch(`${NOTION_API}/search`, {
+        method: 'POST',
+        headers: notionHeaders(apiKey),
+        body: JSON.stringify({ sort: { direction: 'descending', timestamp: 'last_edited_time' }, page_size: 10 }),
+      });
+      if (resp.ok) {
+        const data = await resp.json() as { results: Array<{ id: string; object: string }> };
+        for (const r of data.results) {
+          if (r.object === 'page') {
+            const page = await fetchNotionPage(r.id, apiKey);
+            if (page) items.push(page);
+          }
+        }
+      }
+    }
+
+    res.json({ status: 'ok', data: items });
+  } catch (err) { connectorError(res, 'Notion', err); }
+});
+
+// ── Helpers ──
+
+async function fetchNotionPage(pageId: string, apiKey: string) {
+  const pageResp = await fetch(`${NOTION_API}/pages/${pageId}`, { headers: notionHeaders(apiKey) });
+  if (!pageResp.ok) return null;
+  const page = await pageResp.json() as { id: string; properties: Record<string, any> };
+
+  // Get title
+  const titleProp = Object.values(page.properties).find((p: any) => p.type === 'title');
+  const title = (titleProp as any)?.title?.[0]?.plain_text ?? page.id;
+
+  // Get blocks
+  const blocks = await fetchAllBlocks(pageId, apiKey);
+  const content = blocksToMarkdown(blocks);
+  return { id: pageId, title, content, tokens: Math.ceil(content.length / 4) };
+}
+
+async function queryNotionDatabase(dbId: string, apiKey: string) {
+  const items: Array<{ id: string; title: string; content: string; tokens: number }> = [];
+  let cursor: string | undefined;
+  do {
+    const body = JSON.stringify(cursor ? { start_cursor: cursor } : {});
+    const resp = await fetch(`${NOTION_API}/databases/${dbId}/query`, {
+      method: 'POST', headers: notionHeaders(apiKey), body,
+    });
+    if (!resp.ok) break;
+    const data = await resp.json() as { results: Array<{ id: string; properties: Record<string, any> }>; has_more: boolean; next_cursor: string | null };
+    for (const row of data.results) {
+      const titleProp = Object.values(row.properties).find((p: any) => p.type === 'title');
+      const title = (titleProp as any)?.title?.[0]?.plain_text ?? row.id;
+      items.push({ id: row.id, title, content: `# ${title}`, tokens: Math.ceil(title.length / 4) + 10 });
+    }
+    cursor = data.has_more && data.next_cursor ? data.next_cursor : undefined;
+  } while (cursor);
+  return items;
+}
+
+async function fetchAllBlocks(pageId: string, apiKey: string) {
+  const blocks: Array<{ type: string; [k: string]: any }> = [];
+  let cursor: string | undefined;
+  do {
+    const qs = cursor ? `?start_cursor=${encodeURIComponent(cursor)}` : '';
+    const resp = await fetch(`${NOTION_API}/blocks/${pageId}/children${qs}`, { headers: notionHeaders(apiKey) });
+    if (!resp.ok) break;
+    const data = await resp.json() as { results: any[]; has_more: boolean; next_cursor: string | null };
+    blocks.push(...data.results);
+    cursor = data.has_more && data.next_cursor ? data.next_cursor : undefined;
+  } while (cursor);
+  return blocks;
+}
+
+function blocksToMarkdown(blocks: Array<{ type: string; [k: string]: any }>): string {
+  const lines: string[] = [];
+  for (const b of blocks) {
+    const content = b[b.type];
+    if (!content || typeof content !== 'object') continue;
+    const rt = content.rich_text;
+    if (!Array.isArray(rt)) continue;
+    const text = rt.map((r: any) => r.plain_text ?? '').join('');
+    if (!text) continue;
+    if (b.type === 'heading_1') lines.push(`# ${text}`);
+    else if (b.type === 'heading_2') lines.push(`## ${text}`);
+    else if (b.type === 'heading_3') lines.push(`### ${text}`);
+    else if (b.type === 'bulleted_list_item') lines.push(`- ${text}`);
+    else if (b.type === 'numbered_list_item') lines.push(`1. ${text}`);
+    else if (b.type === 'code') lines.push(`\`\`\`\n${text}\n\`\`\``);
+    else lines.push(text);
+  }
+  return lines.join('\n');
+}
+
+export default router;

--- a/src/components/test/ActivityFeed.tsx
+++ b/src/components/test/ActivityFeed.tsx
@@ -1,0 +1,144 @@
+import { useRef, useEffect } from 'react';
+import { Brain, MessageSquare, Play } from 'lucide-react';
+import { useTheme } from '../../theme';
+import { ToolCallCard } from './ToolCallCard';
+import { TurnProgress } from './TurnProgress';
+import type { ToolEvent } from '../../store/activityStore';
+
+interface ActivityFeedProps {
+  events: ToolEvent[];
+  currentTurn: number;
+  maxTurns: number;
+  running: boolean;
+  thinking?: string;
+}
+
+interface TurnGroup {
+  turnNumber: number;
+  events: ToolEvent[];
+}
+
+function groupByTurn(events: ToolEvent[]): TurnGroup[] {
+  const groups: TurnGroup[] = [];
+  let current: TurnGroup | null = null;
+
+  for (const evt of events) {
+    if (evt.type === 'turn_start') {
+      current = { turnNumber: evt.turnNumber ?? groups.length + 1, events: [] };
+      groups.push(current);
+    } else if (current) {
+      current.events.push(evt);
+    } else {
+      // Events before any turn_start — put in turn 1
+      current = { turnNumber: 1, events: [evt] };
+      groups.push(current);
+    }
+  }
+
+  return groups;
+}
+
+export function ActivityFeed({ events, currentTurn, maxTurns, running, thinking }: ActivityFeedProps) {
+  const t = useTheme();
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [events.length]);
+
+  const groups = groupByTurn(events);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      {/* Turn progress */}
+      {(running || events.length > 0) && (
+        <TurnProgress current={currentTurn} max={maxTurns} running={running} />
+      )}
+
+      {groups.map((group) => {
+        // Pair tool_start events with their tool_result/tool_error by order (i-th start → i-th result)
+        const toolStarts = group.events.filter(e => e.type === 'tool_start');
+        const toolResults = group.events.filter(e => e.type === 'tool_result' || e.type === 'tool_error');
+        const resultByIndex = new Map<number, ToolEvent>();
+        toolResults.forEach((evt, i) => resultByIndex.set(i, evt));
+
+        const thinkingEvents = group.events.filter(e => e.type === 'thinking');
+        const doneEvents = group.events.filter(e => e.type === 'done' || e.type === 'turn_end');
+
+        return (
+          <div key={group.turnNumber}>
+            {/* Turn header */}
+            <div className="flex items-center gap-2" style={{ marginBottom: 6 }}>
+              <Play size={10} style={{ color: '#FE5000', flexShrink: 0 }} />
+              <span style={{
+                fontFamily: "'Geist Mono', monospace",
+                fontSize: 10,
+                color: t.textFaint,
+                textTransform: 'uppercase',
+                letterSpacing: '0.05em',
+              }}>
+                Turn {group.turnNumber}
+              </span>
+              <div style={{ flex: 1, height: 1, background: t.border }} />
+            </div>
+
+            {/* Thinking text */}
+            {thinkingEvents.map(evt => (
+              <div key={evt.id} className="flex items-start gap-2" style={{ marginBottom: 4 }}>
+                <Brain size={12} style={{ color: '#9b59b6', flexShrink: 0, marginTop: 2 }} />
+                <span style={{
+                  fontFamily: "'Geist Sans', sans-serif",
+                  fontSize: 12,
+                  color: t.textDim,
+                  fontStyle: 'italic',
+                }}>
+                  {evt.result}
+                </span>
+              </div>
+            ))}
+
+            {/* Tool call cards */}
+            {toolStarts.map((evt, i) => (
+              <ToolCallCard
+                key={evt.id}
+                event={evt}
+                resultEvent={resultByIndex.get(i)}
+              />
+            ))}
+
+            {/* Done / final text */}
+            {doneEvents.map(evt => evt.result ? (
+              <div key={evt.id} className="flex items-start gap-2" style={{ marginTop: 4 }}>
+                <MessageSquare size={12} style={{ color: t.textDim, flexShrink: 0, marginTop: 2 }} />
+                <span style={{
+                  fontFamily: "'Geist Sans', sans-serif",
+                  fontSize: 12,
+                  color: t.textSecondary,
+                }}>
+                  {evt.result}
+                </span>
+              </div>
+            ) : null)}
+          </div>
+        );
+      })}
+
+      {/* Live thinking / streaming text */}
+      {thinking && running && (
+        <div className="flex items-start gap-2">
+          <Brain size={12} style={{ color: '#9b59b6', flexShrink: 0, marginTop: 2 }} />
+          <span style={{
+            fontFamily: "'Geist Sans', sans-serif",
+            fontSize: 12,
+            color: t.textDim,
+            fontStyle: 'italic',
+          }}>
+            {thinking}
+          </span>
+        </div>
+      )}
+
+      <div ref={bottomRef} />
+    </div>
+  );
+}

--- a/src/components/test/BlockExplorer.tsx
+++ b/src/components/test/BlockExplorer.tsx
@@ -1,0 +1,210 @@
+import { useState } from 'react';
+import { useTheme } from '../../theme';
+import { ChevronRight, ChevronDown, Cpu, BookOpen, Brain, Lightbulb, MessageSquare, Wrench } from 'lucide-react';
+
+export interface ContextBlock {
+  id: string;
+  label: string;
+  category: 'system' | 'knowledge' | 'memory' | 'lessons' | 'history' | 'tools';
+  tokens: number;
+  content?: string;
+  children?: ContextBlock[];
+  cached?: boolean;
+  depth?: number;
+  compression?: number;
+}
+
+interface BlockExplorerProps {
+  blocks: ContextBlock[];
+  onBlockClick?: (blockId: string) => void;
+}
+
+const CATEGORY_COLORS: Record<string, string> = {
+  system: '#6366f1',
+  knowledge: '#f59e0b',
+  memory: '#8b5cf6',
+  lessons: '#14b8a6',
+  history: '#64748b',
+  tools: '#ef4444',
+};
+
+const DEPTH_LABELS: Record<number, string> = {
+  0: 'Full',
+  1: 'Detailed',
+  2: 'Summary',
+  3: 'Brief',
+  4: 'Mention',
+};
+
+function CategoryIcon({ category }: { category: string }) {
+  const color = CATEGORY_COLORS[category] ?? '#888';
+  const size = 12;
+  const props = { size, style: { color } };
+  switch (category) {
+    case 'system': return <Cpu {...props} />;
+    case 'knowledge': return <BookOpen {...props} />;
+    case 'memory': return <Brain {...props} />;
+    case 'lessons': return <Lightbulb {...props} />;
+    case 'history': return <MessageSquare {...props} />;
+    case 'tools': return <Wrench {...props} />;
+    default: return <BookOpen {...props} />;
+  }
+}
+
+function formatK(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}K`;
+  return String(n);
+}
+
+function BlockNode({
+  block,
+  onBlockClick,
+}: {
+  block: ContextBlock;
+  onBlockClick?: (blockId: string) => void;
+}) {
+  const t = useTheme();
+  const [expanded, setExpanded] = useState(false);
+  const hasChildren = block.children && block.children.length > 0;
+  const hasContent = !!block.content;
+  const expandable = hasChildren || hasContent;
+
+  const color = CATEGORY_COLORS[block.category] ?? '#888';
+
+  return (
+    <div>
+      <div
+        className="flex items-center gap-1.5 py-1 px-2 rounded cursor-pointer group"
+        style={{
+          background: expanded ? t.surfaceElevated : 'transparent',
+          borderLeft: block.cached ? `2px solid #22c55e` : `2px solid transparent`,
+        }}
+        onClick={() => {
+          if (expandable) setExpanded(!expanded);
+          onBlockClick?.(block.id);
+        }}
+      >
+        {/* Expand toggle */}
+        <div style={{ width: 12, color: t.textDim, flexShrink: 0 }}>
+          {expandable
+            ? expanded
+              ? <ChevronDown size={12} />
+              : <ChevronRight size={12} />
+            : null}
+        </div>
+
+        {/* Category icon */}
+        <CategoryIcon category={block.category} />
+
+        {/* Label */}
+        <span
+          className="flex-1 truncate"
+          style={{ fontSize: 11, color: t.textSecondary, fontFamily: "'Geist Sans', sans-serif" }}
+        >
+          {block.label}
+        </span>
+
+        {/* Badges */}
+        <div className="flex items-center gap-1 flex-shrink-0">
+          {block.cached && (
+            <span
+              style={{
+                fontSize: 9,
+                fontFamily: "'Geist Mono', monospace",
+                color: '#22c55e',
+                background: 'rgba(34,197,94,0.12)',
+                border: '1px solid rgba(34,197,94,0.3)',
+                borderRadius: 3,
+                padding: '0 4px',
+              }}
+            >
+              cached
+            </span>
+          )}
+          {block.depth != null && (
+            <span
+              style={{
+                fontSize: 9,
+                fontFamily: "'Geist Mono', monospace",
+                color,
+                background: `${color}18`,
+                border: `1px solid ${color}30`,
+                borderRadius: 3,
+                padding: '0 4px',
+              }}
+            >
+              {DEPTH_LABELS[block.depth] ?? `D${block.depth}`}
+            </span>
+          )}
+          <span
+            style={{ fontSize: 10, fontFamily: "'Geist Mono', monospace", color: t.textDim, minWidth: 32, textAlign: 'right' }}
+          >
+            {formatK(block.tokens)}
+          </span>
+        </div>
+      </div>
+
+      {/* Expanded content */}
+      {expanded && (
+        <div style={{ marginLeft: 26 }}>
+          {hasContent && (
+            <div
+              style={{
+                fontSize: 10,
+                fontFamily: "'Geist Mono', monospace",
+                color: t.textDim,
+                background: t.surfaceElevated,
+                border: `1px solid ${t.border}`,
+                borderRadius: 4,
+                padding: '6px 8px',
+                margin: '2px 0 4px 0',
+                whiteSpace: 'pre-wrap',
+                overflowWrap: 'break-word',
+                lineHeight: 1.5,
+              }}
+            >
+              {(block.content ?? '').split('\n').slice(0, 5).join('\n')}
+              {(block.content ?? '').split('\n').length > 5 && (
+                <span style={{ color: t.textDim, opacity: 0.6 }}>{'\n'}…</span>
+              )}
+            </div>
+          )}
+          {hasChildren &&
+            block.children!
+              .slice()
+              .sort((a, b) => b.tokens - a.tokens)
+              .map((child) => (
+                <BlockNode key={child.id} block={child} onBlockClick={onBlockClick} />
+              ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function BlockExplorer({ blocks, onBlockClick }: BlockExplorerProps) {
+  const t = useTheme();
+
+  if (blocks.length === 0) {
+    return (
+      <div style={{ fontSize: 11, color: t.textDim, textAlign: 'center', padding: '12px 0' }}>
+        No blocks
+      </div>
+    );
+  }
+
+  const sorted = [...blocks].sort((a, b) => b.tokens - a.tokens);
+
+  return (
+    <div style={{ border: `1px solid ${t.border}`, borderRadius: 6, overflow: 'hidden' }}>
+      {sorted.map((block, i) => (
+        <div
+          key={block.id}
+          style={{ borderBottom: i < sorted.length - 1 ? `1px solid ${t.border}` : 'none' }}
+        >
+          <BlockNode block={block} onBlockClick={onBlockClick} />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/test/ContextInspector.tsx
+++ b/src/components/test/ContextInspector.tsx
@@ -1,11 +1,10 @@
 import { useState, useEffect } from 'react';
 import { useTheme } from '../../theme';
 import { useConversationStore } from '../../store/conversationStore';
-import { useGraphStore } from '../../store/graphStore';
-import { Search, GitCompare, ChevronDown, ChevronUp } from 'lucide-react';
+import { Search, GitCompare } from 'lucide-react';
 import type { PipelineChatStats } from '../../services/pipelineChat';
-import ContextTrace from '../ContextTrace';
-import type { EntryPoint, PackedItem, FileLanguage, SymbolKind } from '../../graph/types';
+import { TokenBudgetBar, type TokenBudgetBarSegment } from './TokenBudgetBar';
+import { BlockExplorer } from './BlockExplorer';
 
 interface ContextInspectorProps {
   conversationId?: string;
@@ -14,10 +13,8 @@ interface ContextInspectorProps {
 export function ContextInspector(_props: ContextInspectorProps) {
   const t = useTheme();
   const lastPipelineStats = useConversationStore(s => s.lastPipelineStats);
-  const lastQueryResult = useGraphStore(s => s.lastQueryResult);
   const [showDiff, setShowDiff] = useState(false);
   const [previousStats, setPreviousStats] = useState<PipelineChatStats | null>(null);
-  const [graphTraceCollapsed, setGraphTraceCollapsed] = useState(true);
 
   // Store previous stats when new stats come in
   useEffect(() => {
@@ -79,6 +76,56 @@ export function ContextInspector(_props: ContextInspectorProps) {
           )}
         </div>
       </div>
+
+      {/* Token Budget Bar */}
+      {lastPipelineStats && (() => {
+        const segments: TokenBudgetBarSegment[] = [];
+        const s = lastPipelineStats;
+        if (s.systemTokens) segments.push({ label: 'System', tokens: s.systemTokens, color: '#6366f1' });
+        if (s.contextBlocks) {
+          const knowledgeTokens = s.contextBlocks.filter(b => b.category === 'knowledge').reduce((sum, b) => sum + b.tokens, 0);
+          const memoryTokens = s.contextBlocks.filter(b => b.category === 'memory').reduce((sum, b) => sum + b.tokens, 0);
+          const lessonTokens = s.contextBlocks.filter(b => b.category === 'lessons').reduce((sum, b) => sum + b.tokens, 0);
+          const historyTokens = s.contextBlocks.filter(b => b.category === 'history').reduce((sum, b) => sum + b.tokens, 0);
+          const toolTokens = s.contextBlocks.filter(b => b.category === 'tools').reduce((sum, b) => sum + b.tokens, 0);
+          if (knowledgeTokens) segments.push({ label: 'Knowledge', tokens: knowledgeTokens, color: '#f59e0b' });
+          if (memoryTokens) segments.push({ label: 'Memory', tokens: memoryTokens, color: '#8b5cf6' });
+          if (lessonTokens) segments.push({ label: 'Lessons', tokens: lessonTokens, color: '#14b8a6' });
+          if (historyTokens) segments.push({ label: 'History', tokens: historyTokens, color: '#64748b' });
+          if (toolTokens) segments.push({ label: 'Tools', tokens: toolTokens, color: '#ef4444' });
+        } else {
+          // Fallback: derive from total - system
+          const rest = (s.totalContextTokens ?? 0) - (s.systemTokens ?? 0);
+          if (rest > 0) segments.push({ label: 'Knowledge + History', tokens: rest, color: '#f59e0b' });
+        }
+        return (
+          <div className="px-3 py-2 border-b" style={{ borderColor: t.border }}>
+            <TokenBudgetBar
+              segments={segments}
+              budget={s.contextBudget ?? 200000}
+              cacheBoundary={s.cacheBoundaryTokens}
+            />
+          </div>
+        );
+      })()}
+
+      {/* Block Explorer */}
+      {lastPipelineStats?.contextBlocks && lastPipelineStats.contextBlocks.length > 0 && (
+        <div className="px-3 py-2 border-b" style={{ borderColor: t.border }}>
+          <BlockExplorer
+            blocks={lastPipelineStats.contextBlocks.map(b => ({
+              id: b.id,
+              label: b.label,
+              category: b.category,
+              tokens: b.tokens,
+              cached: b.cached,
+              depth: b.depth,
+              compression: b.compression,
+              content: b.preview,
+            }))}
+          />
+        </div>
+      )}
 
       {/* Content */}
       <div className="flex-1 overflow-auto p-3" style={{ background: t.surface }}>
@@ -205,70 +252,6 @@ export function ContextInspector(_props: ContextInspectorProps) {
           </div>
         )}
       </div>
-
-      {/* Context Graph Trace — only when a query result exists */}
-      {lastQueryResult && (() => {
-        const entryPoints: EntryPoint[] = lastQueryResult.entryPoints.map(ep => ({
-          fileId: ep.fileId,
-          symbolName: ep.symbol,
-          confidence: ep.confidence,
-          reason: ep.reason as EntryPoint['reason'],
-        }));
-
-        const packedItems: PackedItem[] = lastQueryResult.items.map(item => ({
-          file: {
-            id: item.path,
-            path: item.path,
-            language: item.language as FileLanguage,
-            tokens: item.tokens,
-            symbols: item.symbols.map(s => ({
-              name: s.name,
-              kind: s.kind as SymbolKind,
-              lineStart: 0,
-              lineEnd: 0,
-              isExported: s.exported,
-            })),
-            lastModified: 0,
-            contentHash: '',
-          },
-          content: '',
-          depth: item.depth,
-          tokens: item.tokens,
-          relevance: item.relevance,
-        }));
-
-        return (
-          <div
-            className="flex-shrink-0 border-t"
-            style={{ borderColor: t.border, background: t.surface }}
-          >
-            <button
-              onClick={() => setGraphTraceCollapsed(c => !c)}
-              className="w-full px-3 py-2 flex items-center justify-between text-left"
-              style={{ background: t.surfaceElevated, color: t.textPrimary }}
-            >
-              <span className="text-xs font-medium" style={{ fontFamily: "'Geist Sans', sans-serif" }}>
-                Context Graph Trace
-              </span>
-              {graphTraceCollapsed
-                ? <ChevronDown size={14} style={{ color: t.textSecondary }} />
-                : <ChevronUp size={14} style={{ color: t.textSecondary }} />
-              }
-            </button>
-            {!graphTraceCollapsed && (
-              <div className="p-3 overflow-auto" style={{ maxHeight: 400 }}>
-                <ContextTrace
-                  entryPoints={entryPoints}
-                  packedItems={packedItems}
-                  totalTokens={lastQueryResult.totalTokens}
-                  tokenBudget={100000}
-                  taskType="explain"
-                />
-              </div>
-            )}
-          </div>
-        );
-      })()}
     </div>
   );
 }

--- a/src/components/test/TokenBudgetBar.tsx
+++ b/src/components/test/TokenBudgetBar.tsx
@@ -1,0 +1,145 @@
+import { useState, useRef } from 'react';
+import { useTheme } from '../../theme';
+
+export interface TokenBudgetBarSegment {
+  label: string;
+  tokens: number;
+  color: string;
+}
+
+interface TokenBudgetBarProps {
+  segments: TokenBudgetBarSegment[];
+  budget: number;
+  cacheBoundary?: number;
+  onSegmentClick?: (label: string) => void;
+}
+
+function formatK(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}K`;
+  return String(n);
+}
+
+export function TokenBudgetBar({ segments, budget, cacheBoundary, onSegmentClick }: TokenBudgetBarProps) {
+  const t = useTheme();
+  const barRef = useRef<HTMLDivElement>(null);
+  const [tooltip, setTooltip] = useState<{
+    label: string;
+    tokens: number;
+    pct: number;
+    x: number;
+  } | null>(null);
+
+  const used = segments.reduce((s, seg) => s + seg.tokens, 0);
+  const free = Math.max(0, budget - used);
+
+  const handleMouseEnter = (
+    e: React.MouseEvent,
+    label: string,
+    tokens: number,
+    pct: number,
+  ) => {
+    const rect = barRef.current?.getBoundingClientRect();
+    setTooltip({ label, tokens, pct, x: e.clientX - (rect?.left ?? 0) });
+  };
+
+  return (
+    <div>
+      {/* Bar */}
+      <div
+        ref={barRef}
+        className="relative w-full rounded overflow-hidden"
+        style={{ height: 20, background: t.surfaceElevated, border: `1px solid ${t.border}` }}
+      >
+        <div className="flex h-full">
+          {segments.map((seg, i) => {
+            const pct = budget > 0 ? (seg.tokens / budget) * 100 : 0;
+            if (pct < 0.1) return null;
+            return (
+              <div
+                key={i}
+                style={{ width: `${pct}%`, background: seg.color, opacity: 0.85, cursor: onSegmentClick ? 'pointer' : 'default', minWidth: 2 }}
+                onMouseEnter={(e) => handleMouseEnter(e, seg.label, seg.tokens, pct)}
+                onMouseLeave={() => setTooltip(null)}
+                onClick={() => onSegmentClick?.(seg.label)}
+              />
+            );
+          })}
+          {free > 0 && budget > 0 && (
+            <div
+              style={{ width: `${(free / budget) * 100}%`, background: t.border, opacity: 0.25 }}
+              onMouseEnter={(e) => handleMouseEnter(e, 'Free', free, (free / budget) * 100)}
+              onMouseLeave={() => setTooltip(null)}
+            />
+          )}
+        </div>
+
+        {/* Cache boundary marker */}
+        {cacheBoundary != null && cacheBoundary > 0 && budget > 0 && (
+          <div
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: `${Math.min((cacheBoundary / budget) * 100, 99)}%`,
+              height: '100%',
+              width: 2,
+              background: '#22c55e',
+              opacity: 0.9,
+            }}
+          />
+        )}
+
+        {/* Tooltip */}
+        {tooltip && (
+          <div
+            style={{
+              position: 'absolute',
+              top: '110%',
+              left: Math.min(tooltip.x, (barRef.current?.clientWidth ?? 200) - 130),
+              background: t.surfaceElevated,
+              border: `1px solid ${t.border}`,
+              color: t.textPrimary,
+              padding: '3px 7px',
+              borderRadius: 4,
+              fontSize: 11,
+              fontFamily: "'Geist Mono', monospace",
+              whiteSpace: 'nowrap',
+              zIndex: 20,
+              pointerEvents: 'none',
+              boxShadow: '0 2px 8px rgba(0,0,0,0.2)',
+            }}
+          >
+            {tooltip.label}: {formatK(tooltip.tokens)} ({tooltip.pct.toFixed(1)}%)
+          </div>
+        )}
+      </div>
+
+      {/* Legend */}
+      <div className="flex flex-wrap gap-x-3 gap-y-1 mt-1.5">
+        {segments.map((seg, i) => (
+          <div key={i} className="flex items-center gap-1">
+            <div style={{ width: 8, height: 8, borderRadius: 2, background: seg.color, opacity: 0.85, flexShrink: 0 }} />
+            <span style={{ fontSize: 10, color: t.textDim, fontFamily: "'Geist Mono', monospace" }}>
+              {seg.label} {formatK(seg.tokens)}
+            </span>
+          </div>
+        ))}
+        {free > 0 && (
+          <div className="flex items-center gap-1">
+            <div style={{ width: 8, height: 8, borderRadius: 2, background: t.border, opacity: 0.4, flexShrink: 0 }} />
+            <span style={{ fontSize: 10, color: t.textDim, fontFamily: "'Geist Mono', monospace" }}>
+              Free {formatK(free)}
+            </span>
+          </div>
+        )}
+        {cacheBoundary != null && cacheBoundary > 0 && (
+          <div className="flex items-center gap-1">
+            <div style={{ width: 8, height: 8, borderRadius: 1, background: '#22c55e', opacity: 0.9, flexShrink: 0 }} />
+            <span style={{ fontSize: 10, color: t.textDim, fontFamily: "'Geist Mono', monospace" }}>
+              Cache {formatK(cacheBoundary)}
+            </span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/test/ToolCallCard.tsx
+++ b/src/components/test/ToolCallCard.tsx
@@ -1,0 +1,177 @@
+import { useState } from 'react';
+import { Wrench, Check, X, Loader2 } from 'lucide-react';
+import { useTheme } from '../../theme';
+import type { ToolEvent } from '../../store/activityStore';
+
+interface ToolCallCardProps {
+  event: ToolEvent;
+  resultEvent?: ToolEvent;
+  defaultExpanded?: boolean;
+}
+
+function argsSummary(args: Record<string, unknown> | undefined): string {
+  if (!args) return '';
+  const entries = Object.entries(args)
+    .map(([k, v]) => `${k}: ${typeof v === 'string' ? JSON.stringify(v) : JSON.stringify(v)}`)
+    .join(', ');
+  return entries.length > 80 ? entries.slice(0, 77) + '...' : entries;
+}
+
+export function ToolCallCard({ event, resultEvent, defaultExpanded = false }: ToolCallCardProps) {
+  const t = useTheme();
+  const [expanded, setExpanded] = useState(defaultExpanded);
+
+  const isRunning = !resultEvent;
+  const isError = resultEvent?.type === 'tool_error';
+  const isSuccess = resultEvent?.type === 'tool_result';
+
+  const statusColor = isRunning ? '#3498db' : isError ? '#e74c3c' : '#2ecc71';
+  const borderColor = isRunning ? '#3498db30' : isError ? '#e74c3c30' : '#2ecc7130';
+
+  return (
+    <div
+      style={{
+        border: `1px solid ${borderColor}`,
+        borderRadius: 6,
+        overflow: 'hidden',
+        background: t.isDark ? '#13131a' : '#f8f8fc',
+        marginBottom: 4,
+      }}
+    >
+      {/* Header */}
+      <button
+        type="button"
+        onClick={() => setExpanded(e => !e)}
+        className="flex items-center gap-2 w-full text-left border-none cursor-pointer"
+        style={{
+          padding: '6px 10px',
+          background: 'transparent',
+          minHeight: 36,
+        }}
+      >
+        {/* Tool icon */}
+        <Wrench size={12} style={{ color: statusColor, flexShrink: 0 }} />
+
+        {/* Tool name */}
+        <span style={{
+          fontFamily: "'Geist Mono', monospace",
+          fontSize: 12,
+          color: t.textPrimary,
+          fontWeight: 500,
+        }}>
+          {event.toolName}
+        </span>
+
+        {/* Server badge */}
+        {event.serverName && (
+          <span style={{
+            fontSize: 10,
+            padding: '1px 5px',
+            borderRadius: 3,
+            background: t.isDark ? '#2a2a35' : '#e8e8f0',
+            color: t.textDim,
+            fontFamily: "'Geist Mono', monospace",
+          }}>
+            {event.serverName}
+          </span>
+        )}
+
+        {/* Status indicator */}
+        <span style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 4 }}>
+          {isRunning && (
+            <Loader2
+              size={12}
+              style={{ color: '#3498db', animation: 'spin 1s linear infinite' }}
+            />
+          )}
+          {isSuccess && <Check size={12} style={{ color: '#2ecc71' }} />}
+          {isError && <X size={12} style={{ color: '#e74c3c' }} />}
+
+          {resultEvent?.durationMs != null && (
+            <span style={{
+              fontFamily: "'Geist Mono', monospace",
+              fontSize: 10,
+              color: t.textFaint,
+            }}>
+              {resultEvent.durationMs}ms
+            </span>
+          )}
+        </span>
+
+        <style>{`@keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }`}</style>
+      </button>
+
+      {/* Collapsed one-liner */}
+      {!expanded && event.args && (
+        <div style={{
+          padding: '0 10px 6px',
+          fontFamily: "'Geist Mono', monospace",
+          fontSize: 11,
+          color: t.textFaint,
+          whiteSpace: 'nowrap',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+        }}>
+          {argsSummary(event.args)}
+        </div>
+      )}
+
+      {/* Expanded detail */}
+      {expanded && (
+        <div style={{
+          borderTop: `1px solid ${t.border}`,
+          padding: '8px 10px',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 8,
+        }}>
+          {event.args && (
+            <div>
+              <div style={{ fontSize: 10, color: t.textDim, fontFamily: "'Geist Sans', sans-serif", marginBottom: 3 }}>
+                Arguments
+              </div>
+              <pre style={{
+                margin: 0,
+                fontFamily: "'Geist Mono', monospace",
+                fontSize: 11,
+                color: t.textSecondary,
+                background: t.isDark ? '#0d0d12' : '#ebebf5',
+                borderRadius: 4,
+                padding: '6px 8px',
+                overflowX: 'auto',
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-word',
+              }}>
+                {JSON.stringify(event.args, null, 2)}
+              </pre>
+            </div>
+          )}
+
+          {resultEvent && (resultEvent.result || resultEvent.error) && (
+            <div>
+              <div style={{ fontSize: 10, color: t.textDim, fontFamily: "'Geist Sans', sans-serif", marginBottom: 3 }}>
+                {resultEvent.error ? 'Error' : 'Result'}
+              </div>
+              <pre style={{
+                margin: 0,
+                fontFamily: "'Geist Mono', monospace",
+                fontSize: 11,
+                color: isError ? '#e74c3c' : t.textSecondary,
+                background: t.isDark ? '#0d0d12' : '#ebebf5',
+                borderRadius: 4,
+                padding: '6px 8px',
+                overflowX: 'auto',
+                overflowY: 'auto',
+                maxHeight: 300,
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-word',
+              }}>
+                {resultEvent.error ?? resultEvent.result}
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/test/TurnProgress.tsx
+++ b/src/components/test/TurnProgress.tsx
@@ -1,0 +1,46 @@
+import { useTheme } from '../../theme';
+
+interface TurnProgressProps {
+  current: number;
+  max: number;
+  running: boolean;
+}
+
+export function TurnProgress({ current, max, running }: TurnProgressProps) {
+  const t = useTheme();
+  const pct = max > 0 ? Math.min(current / max, 1) : 0;
+
+  return (
+    <div className="flex items-center gap-2" style={{ fontFamily: "'Geist Mono', monospace", fontSize: 11 }}>
+      <span style={{ color: t.textDim }}>
+        Turn {current}/{max}
+      </span>
+      <div
+        style={{
+          width: 80,
+          height: 4,
+          borderRadius: 2,
+          background: t.isDark ? '#2a2a30' : '#e0e0e8',
+          overflow: 'hidden',
+        }}
+      >
+        <div
+          style={{
+            width: `${pct * 100}%`,
+            height: '100%',
+            borderRadius: 2,
+            background: running ? '#3498db' : '#2ecc71',
+            transition: 'width 300ms ease',
+            animation: running ? 'pulse 1.5s ease-in-out infinite' : 'none',
+          }}
+        />
+      </div>
+      <style>{`
+        @keyframes pulse {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.5; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/src/panels/TestPanel.tsx
+++ b/src/panels/TestPanel.tsx
@@ -23,6 +23,9 @@ import { getCapabilityMatrix, type CapabilityKey } from '../capabilities';
 import { CapabilityGate } from '../components/CapabilityGate';
 import { RuntimeResults } from './RuntimePanel';
 import { PipelineTraceView } from '../components/PipelineTraceView';
+import { useActivityStore } from '../store/activityStore';
+import { ActivityFeed } from '../components/test/ActivityFeed';
+import { TurnProgress } from '../components/test/TurnProgress';
 
 import { API_BASE } from '../config';
 import { runTeam as runTeamService, type RunTeamConfig } from '../services/runtimeService';
@@ -536,6 +539,10 @@ function ChatSection() {
   const mcpServers = useConsoleStore(s => s.mcpServers);
   const agentMeta = useConsoleStore(s => s.agentMeta);
   const navigationMode = useConsoleStore(s => s.navigationMode);
+  const activityEvents = useActivityStore(s => s.events);
+  const activityCurrentTurn = useActivityStore(s => s.currentTurn);
+  const activityMaxTurns = useActivityStore(s => s.maxTurns);
+  const activityRunning = useActivityStore(s => s.running);
 
   // Derive required capabilities from agent config
   const requiredCapabilities: CapabilityKey[] = (() => {
@@ -688,6 +695,12 @@ function ChatSection() {
               borderBottomRightRadius: msg.role === 'user' ? 4 : 12,
               borderBottomLeftRadius: msg.role === 'assistant' ? 4 : 12,
             }}>
+            {msg.role === 'assistant' && streaming && activityEvents.length > 0 && (
+              <div style={{ marginBottom: 8 }}>
+                <TurnProgress current={activityCurrentTurn} max={activityMaxTurns} running={activityRunning} />
+                <ActivityFeed events={activityEvents} currentTurn={activityCurrentTurn} maxTurns={activityMaxTurns} running={activityRunning} />
+              </div>
+            )}
             {msg.role === 'assistant' ? (
               <ReactMarkdown
                 remarkPlugins={[remarkGfm]}

--- a/src/services/executionRouter.ts
+++ b/src/services/executionRouter.ts
@@ -6,6 +6,7 @@
 
 import { streamCompletion, streamAgentSdk, type MessageContent } from './llmService';
 import { runToolLoop, type ToolCallResult } from './toolRunner';
+import { useActivityStore } from '../store/activityStore';
 import { buildAnthropicCacheBlocks } from './cacheAwareAssembler';
 import { getUnifiedTools, supportsToolCalling } from './toolRegistry';
 import { useProviderStore, type ProviderConfig } from '../store/providerStore';
@@ -66,6 +67,12 @@ export async function executeChat(options: {
       ),
     });
 
+    const activityStore = useActivityStore.getState();
+    activityStore.clear();
+    activityStore.setRunning(true);
+    let currentTurn = 0;
+    let turnStartedForBatch = false;
+
     await new Promise<void>((resolve, reject) => {
       runToolLoop({
         providerId,
@@ -74,18 +81,34 @@ export async function executeChat(options: {
         traceId,
         maxTurns: 10,
         callbacks: {
-          onChunk: (text) => { fullResponse += text; onChunk(text); },
-          onToolCallStart: (name, _args) => {
-            onChunk(`\n\n🔧 Calling **${name}**...\n`);
+          onChunk: (text) => {
+            fullResponse += text;
+            onChunk(text);
+            // Text between tool batches means a new turn is about to start
+            turnStartedForBatch = false;
+            activityStore.pushEvent({ type: 'thinking', result: text });
+          },
+          onToolCallStart: (name, args) => {
+            if (!turnStartedForBatch) {
+              currentTurn++;
+              turnStartedForBatch = true;
+              activityStore.pushEvent({ type: 'turn_start', turnNumber: currentTurn, maxTurns: 10 });
+            }
+            activityStore.pushEvent({ type: 'tool_start', toolName: name, args, turnNumber: currentTurn });
           },
           onToolCallEnd: (result) => {
-            if (result.error) {
-              onChunk(`❌ ${result.name} failed: ${result.error}\n`);
-            } else {
-              onChunk(`✅ ${result.name} (${result.durationMs}ms)\n`);
-            }
+            activityStore.pushEvent({
+              type: result.error ? 'tool_error' : 'tool_result',
+              toolName: result.name,
+              result: result.result,
+              error: result.error,
+              durationMs: result.durationMs,
+              serverName: result.serverId,
+            });
           },
           onDone: (stats) => {
+            activityStore.pushEvent({ type: 'done' });
+            activityStore.setRunning(false);
             toolCallResults = stats.toolCalls;
             toolTurns = stats.turns;
             traceStore.addEvent(traceId, {

--- a/src/services/pipelineChat.ts
+++ b/src/services/pipelineChat.ts
@@ -146,6 +146,18 @@ export interface PipelineChatStats {
       tokens: number;
     }>;
   };
+  contextBlocks?: Array<{
+    id: string;
+    label: string;
+    category: 'system' | 'knowledge' | 'memory' | 'lessons' | 'history' | 'tools';
+    tokens: number;
+    cached: boolean;
+    depth?: number;
+    compression?: number;
+    preview?: string;
+  }>;
+  contextBudget?: number;
+  cacheBoundaryTokens?: number;
 }
 
 // ── Provider/model resolution (shared by all tester surfaces) ──

--- a/src/store/activityStore.ts
+++ b/src/store/activityStore.ts
@@ -1,0 +1,51 @@
+import { create } from 'zustand';
+
+export interface ToolEvent {
+  id: string;
+  type: 'turn_start' | 'tool_start' | 'tool_result' | 'tool_error' | 'thinking' | 'turn_end' | 'done';
+  timestamp: number;
+  turnNumber?: number;
+  maxTurns?: number;
+  toolName?: string;
+  serverName?: string;
+  args?: Record<string, unknown>;
+  result?: string;
+  error?: string;
+  durationMs?: number;
+}
+
+interface ActivityStore {
+  events: ToolEvent[];
+  currentTurn: number;
+  maxTurns: number;
+  running: boolean;
+
+  pushEvent: (event: Omit<ToolEvent, 'id' | 'timestamp'>) => void;
+  clear: () => void;
+  setRunning: (running: boolean) => void;
+}
+
+export const useActivityStore = create<ActivityStore>((set, get) => ({
+  events: [],
+  currentTurn: 0,
+  maxTurns: 10,
+  running: false,
+
+  pushEvent: (event) => {
+    const newEvent: ToolEvent = {
+      ...event,
+      id: `evt-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+      timestamp: Date.now(),
+    };
+    const state = get();
+    const currentTurn = event.type === 'turn_start' && event.turnNumber !== undefined
+      ? event.turnNumber
+      : state.currentTurn;
+    const maxTurns = event.maxTurns ?? state.maxTurns;
+    set({ events: [...state.events, newEvent], currentTurn, maxTurns });
+  },
+
+  clear: () => set({ events: [], currentTurn: 0, maxTurns: 10, running: false }),
+
+  setRunning: (running) => set({ running }),
+}));


### PR DESCRIPTION
## Review PR — All Changes from March 24

This PR captures all changes merged to master today for Codex/Cursor review.

### Features
- **Context Graph Frontend v3** (#121-#126): graphStore, KnowledgeTab integration, TestTab ContextTrace, GraphView v2 UX, Readiness Score Panel, YAML/cross-type extractors
- **Agent IDE** (#68): activityStore, ToolCallCard, ActivityFeed, TurnProgress — SVG icons only
- **Context Inspector v2** (#70): TokenBudgetBar, BlockExplorer, contextBlocks in PipelineChatStats
- **Notion v2 Connector**: test/search/fetch endpoints on /api/connectors/v2/notion

### Bug Fixes
- depth.label crash (DEPTH_LEVELS index vs percentage)
- qualification generate-suite Anthropic SDK detection
- detectCycles GRAY state leak, handleRenderFramePre stale theme, handleNodeHover stale throttle
- Store subscription, result correlation by index, turn counter per LLM turn

### Stats
- ~3,100 lines added across 30+ files
- 67 new tests
- 0 TypeScript errors, 0 emoji (SVG icons only)