### PR TITLE
fix: address Codex review from #148 (3 P1 + 1 P2)

### DIFF
--- a/src/context/PromptRouter.ts
+++ b/src/context/PromptRouter.ts
@@ -30,8 +30,8 @@ export function tokenizePrompt(prompt: string): Set<string> {
   return new Set(
     prompt
       .toLowerCase()
-      .replace(/[^a-z0-9s/_-]/g, '')
-      .split(/[s/_-]+/)
+      .replace(/[^a-z0-9\s\/_-]/g, '')
+      .split(/[\s\/_-]+/)
       .filter(t => t.length >= 2)
   );
 }

--- a/src/context/PromptRouter.ts
+++ b/src/context/PromptRouter.ts
@@ -133,6 +133,5 @@ export function renderRoutedTools<T extends RoutableItem>(matches: RoutedMatch<T
   for (const m of matches) {
     lines.push(`- **${m.item.name}** — ${m.item.description} (relevance: ${m.score})`);
   }
-  return lines.join('
-');
+  return lines.join('\n');
 }

--- a/src/context/ReactiveCompaction.ts
+++ b/src/context/ReactiveCompaction.ts
@@ -68,9 +68,9 @@ export class ReactiveCompaction {
               }
             }
           } else if (signal.ratio >= this.config.pressureThreshold) {
-            // Pressure: downgrade bottom half by one level
+            // Pressure: downgrade least-relevant half by one level
             const half = Math.ceil(sorted.length / 2);
-            for (let i = half; i < sorted.length; i++) {
+            for (let i = 0; i < half; i++) {
               const f = sorted[i];
               const next = this.nextDepth(f.depth);
               if (next) adjustments.push({ fileId: f.fileId, currentDepth: f.depth, newDepth: next, reason: 'token_pressure' });

--- a/src/context/TranscriptCompaction.ts
+++ b/src/context/TranscriptCompaction.ts
@@ -107,8 +107,7 @@ export class TranscriptCompaction {
     if (toolMsgs.length) {
       parts.push(`Tool calls: ${toolMsgs.map(m => m.metadata?.toolName ?? 'unknown').join(', ')}`);
     }
-    return parts.join('
-');
+    return parts.join('\n');
   }
 
   /** Estimate tokens for a string (rough approximation). */

--- a/src/graph/reactivePackerWrapper.ts
+++ b/src/graph/reactivePackerWrapper.ts
@@ -127,7 +127,14 @@ export function withReactiveCompaction(
       const baseTokens = oldRatio > 0 ? item.tokens / oldRatio : item.tokens;
       const newTokens = Math.max(1, Math.ceil(baseTokens * newRatio));
       newTotal += newTokens;
-      return { ...item, depth: newDepthNumeric, tokens: newTokens };
+      // Truncate content proportionally to new depth
+      const contentStr = typeof item.content === 'string' ? item.content : '';
+      const truncatedLength = oldRatio > 0 ? Math.ceil(contentStr.length * (newRatio / oldRatio)) : contentStr.length;
+      const truncatedContent = contentStr.length > truncatedLength
+        ? contentStr.slice(0, truncatedLength) + '
+[... truncated by reactive compaction]'
+        : contentStr;
+      return { ...item, depth: newDepthNumeric, tokens: newTokens, content: truncatedContent };
     }
     newTotal += item.tokens;
     return item;

--- a/src/graph/reactivePackerWrapper.ts
+++ b/src/graph/reactivePackerWrapper.ts
@@ -131,8 +131,7 @@ export function withReactiveCompaction(
       const contentStr = typeof item.content === 'string' ? item.content : '';
       const truncatedLength = oldRatio > 0 ? Math.ceil(contentStr.length * (newRatio / oldRatio)) : contentStr.length;
       const truncatedContent = contentStr.length > truncatedLength
-        ? contentStr.slice(0, truncatedLength) + '
-[... truncated by reactive compaction]'
+        ? contentStr.slice(0, truncatedLength) + '\n[... truncated by reactive compaction]'
         : contentStr;
       return { ...item, depth: newDepthNumeric, tokens: newTokens, content: truncatedContent };
     }

--- a/src/services/agentSearchIntegration.ts
+++ b/src/services/agentSearchIntegration.ts
@@ -43,7 +43,7 @@ export function createAgentSearchService(
   agents: AgentConfig[],
   knowledge: KnowledgeSource[] = [],
 ): AgentSearchService {
-  const hash = JSON.stringify(agents.map(a => a.id).sort());
+  const hash = JSON.stringify(agents.map(a => [a.id, a.description, a.role, ...(a.tags ?? [])].join('|')).sort());
   if (!_searchInstance || hash !== _lastIndexHash) {
     _searchInstance = new AgentSearch(agents, knowledge);
     _lastIndexHash = hash;

--- a/src/services/agentSearchIntegration.ts
+++ b/src/services/agentSearchIntegration.ts
@@ -64,7 +64,7 @@ export function createAgentSearchService(
 
     reindex(newAgents: AgentConfig[], newKnowledge?: KnowledgeSource[]): void {
       _searchInstance = new AgentSearch(newAgents, newKnowledge ?? knowledge);
-      _lastIndexHash = JSON.stringify(newAgents.map(a => a.id).sort());
+      _lastIndexHash = JSON.stringify(newAgents.map(a => [a.id, a.description, a.role, ...(a.tags ?? [])].join('|')).sort());
     },
   };
 }

--- a/src/services/systemFrameBuilder.ts
+++ b/src/services/systemFrameBuilder.ts
@@ -46,8 +46,7 @@ export function buildProvenanceSection(provenance: ProvenanceSummary): string {
     lines.push('</context_provenance>');
   }
   
-  return lines.join('
-');
+  return lines.join('\n');
 }
 
 export function buildSystemFrame(provenance?: ProvenanceSummary): string {

--- a/src/services/systemFrameBuilder.ts
+++ b/src/services/systemFrameBuilder.ts
@@ -61,8 +61,7 @@ export function buildSystemFrame(provenance?: ProvenanceSummary): string {
     if (agentMeta.avatar) identity.push(`Avatar: ${agentMeta.avatar}`);
     if (agentMeta.tags?.length) identity.push(`Tags: ${agentMeta.tags.join(', ')}`);
     parts.push(`<identity>
-${identity.join('
-')}
+${identity.join('\n')}
 </identity>`);
   }
 
@@ -79,17 +78,13 @@ ${identity.join('
       lines.push(`Primary Objective: ${instructionState.objectives.primary}`);
       if (instructionState.objectives.successCriteria.length > 0)
         lines.push(`Success Criteria:
-${instructionState.objectives.successCriteria.map(c => `- ${c}`).join('
-')}`);
+${instructionState.objectives.successCriteria.map(c => `- ${c}`).join('\n')}`);
       if (instructionState.objectives.failureModes.length > 0)
         lines.push(`Failure Modes to Avoid:
-${instructionState.objectives.failureModes.map(f => `- ${f}`).join('
-')}`);
+${instructionState.objectives.failureModes.map(f => `- ${f}`).join('\n')}`);
     }
     parts.push(`<instructions>
-${lines.join('
-
-')}
+${lines.join('\n\n')}
 </instructions>`);
   }
 
@@ -105,8 +100,7 @@ ${lines.join('
   if (instructionState.constraints.customConstraints)
     constraints.push(`Additional constraints: ${instructionState.constraints.customConstraints}`);
   if (constraints.length > 0) parts.push(`<constraints>
-${constraints.map(c => `- ${c}`).join('
-')}
+${constraints.map(c => `- ${c}`).join('\n')}
 </constraints>`);
 
   // Workflow
@@ -127,9 +121,7 @@ ${compiled}
     parts.push(provenanceSection);
   }
 
-  return parts.join('
-
-');
+  return parts.join('\n\n');
 }
 
 /**
@@ -316,7 +308,6 @@ export function buildToolGuide(): string {
   }
 
   return `<tool_guide>
-${lines.join('
-')}
+${lines.join('\n')}
 </tool_guide>`;
 }


### PR DESCRIPTION
## Codex Review Fixes

Addresses all 4 issues flagged by Codex on PR #148 (now merged).

| # | Severity | File | Fix |
|---|---|---|---|
| 1 | **P1** | `PromptRouter.ts` | Regex `s` → `\s` for whitespace splitting |
| 2 | **P1** | `ReactiveCompaction.ts` | Iterate `0..half` (least relevant) instead of `half..end` (most relevant) |
| 3 | **P1** | `reactivePackerWrapper.ts` | Truncate content proportionally after depth adjustment |
| 4 | **P2** | `agentSearchIntegration.ts` | Include description+role+tags in cache key hash |