### PR TITLE
fix: resolve CI build errors from UI/UX Audit merge

### DIFF
--- a/src/components/ds/ExperimentalBadge.tsx
+++ b/src/components/ds/ExperimentalBadge.tsx
@@ -86,13 +86,12 @@ interface ExperimentalGateProps {
 
 export function ExperimentalGate({ feature, children, fallback }: ExperimentalGateProps) {
   const isEnabled = useFeatureFlags((s) => s[feature]);
+  const t = useTheme();
+  const meta = FLAG_META[feature];
 
   if (isEnabled) return <>{children}</>;
 
   if (fallback) return <>{fallback}</>;
-
-  const meta = FLAG_META[feature];
-  const t = useTheme();
 
   return (
     <div

--- a/src/context/PromptRouter.ts
+++ b/src/context/PromptRouter.ts
@@ -133,6 +133,5 @@ export function renderRoutedTools<T extends RoutableItem>(matches: RoutedMatch<T
   for (const m of matches) {
     lines.push(`- **${m.item.name}** — ${m.item.description} (relevance: ${m.score})`);
   }
-  return lines.join('
-');
+  return lines.join('\n');
 }

--- a/src/context/TranscriptCompaction.ts
+++ b/src/context/TranscriptCompaction.ts
@@ -107,8 +107,7 @@ export class TranscriptCompaction {
     if (toolMsgs.length) {
       parts.push(`Tool calls: ${toolMsgs.map(m => m.metadata?.toolName ?? 'unknown').join(', ')}`);
     }
-    return parts.join('
-');
+    return parts.join('\n');
   }
 
   /** Estimate tokens for a string (rough approximation). */

--- a/src/graph/reactivePackerWrapper.ts
+++ b/src/graph/reactivePackerWrapper.ts
@@ -131,8 +131,7 @@ export function withReactiveCompaction(
       const contentStr = typeof item.content === 'string' ? item.content : '';
       const truncatedLength = oldRatio > 0 ? Math.ceil(contentStr.length * (newRatio / oldRatio)) : contentStr.length;
       const truncatedContent = contentStr.length > truncatedLength
-        ? contentStr.slice(0, truncatedLength) + '
-[... truncated by reactive compaction]'
+        ? contentStr.slice(0, truncatedLength) + '\n[... truncated by reactive compaction]'
         : contentStr;
       return { ...item, depth: newDepthNumeric, tokens: newTokens, content: truncatedContent };
     }

--- a/src/panels/builder/ConstraintsSection.tsx
+++ b/src/panels/builder/ConstraintsSection.tsx
@@ -44,8 +44,7 @@ export function ConstraintsSection({ onOpenModal }: { onOpenModal: (config: Cons
       </div>
       <div>
         <span className="text-[13px] font-semibold block mb-1.5" style={{ color: 'var(--m-text-muted)', fontFamily: 'var(--m-font-mono)' }}>Custom Rules</span>
-        {constraints.customConstraints.split('
-').filter(Boolean).map((rule: string, i: number) => (
+        {constraints.customConstraints.split('\n').filter(Boolean).map((rule: string, i: number) => (
           <div key={i} className="flex items-center gap-2 px-3 py-2 rounded-lg mb-1.5" style={{ background: t.isDark ? 'oklch(0.18 0.02 50)' : 'oklch(0.97 0.01 70)', border: `1px solid ${t.isDark ? 'oklch(0.68 0.16 60 / 0.19)' : 'oklch(0.68 0.16 60 / 0.25)'}` }}>
             <div style={{ width: 6, height: 6, borderRadius: '50%', background: 'var(--m-intel)', flexShrink: 0 }} />
             <span className="flex-1 text-[13px]" style={{ color: 'var(--m-text-primary)', lineHeight: 1.4, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{rule}</span>

--- a/src/services/systemFrameBuilder.ts
+++ b/src/services/systemFrameBuilder.ts
@@ -46,8 +46,7 @@ export function buildProvenanceSection(provenance: ProvenanceSummary): string {
     lines.push('</context_provenance>');
   }
   
-  return lines.join('
-');
+  return lines.join('\n');
 }
 
 export function buildSystemFrame(provenance?: ProvenanceSummary): string {
@@ -62,8 +61,7 @@ export function buildSystemFrame(provenance?: ProvenanceSummary): string {
     if (agentMeta.avatar) identity.push(`Avatar: ${agentMeta.avatar}`);
     if (agentMeta.tags?.length) identity.push(`Tags: ${agentMeta.tags.join(', ')}`);
     parts.push(`<identity>
-${identity.join('
-')}
+${identity.join('\n')}
 </identity>`);
   }
 
@@ -80,17 +78,13 @@ ${identity.join('
       lines.push(`Primary Objective: ${instructionState.objectives.primary}`);
       if (instructionState.objectives.successCriteria.length > 0)
         lines.push(`Success Criteria:
-${instructionState.objectives.successCriteria.map(c => `- ${c}`).join('
-')}`);
+${instructionState.objectives.successCriteria.map(c => `- ${c}`).join('\n')}`);
       if (instructionState.objectives.failureModes.length > 0)
         lines.push(`Failure Modes to Avoid:
-${instructionState.objectives.failureModes.map(f => `- ${f}`).join('
-')}`);
+${instructionState.objectives.failureModes.map(f => `- ${f}`).join('\n')}`);
     }
     parts.push(`<instructions>
-${lines.join('
-
-')}
+${lines.join('\n\n')}
 </instructions>`);
   }
 
@@ -106,8 +100,7 @@ ${lines.join('
   if (instructionState.constraints.customConstraints)
     constraints.push(`Additional constraints: ${instructionState.constraints.customConstraints}`);
   if (constraints.length > 0) parts.push(`<constraints>
-${constraints.map(c => `- ${c}`).join('
-')}
+${constraints.map(c => `- ${c}`).join('\n')}
 </constraints>`);
 
   // Workflow
@@ -128,9 +121,7 @@ ${compiled}
     parts.push(provenanceSection);
   }
 
-  return parts.join('
-
-');
+  return parts.join('\n\n');
 }
 
 /**
@@ -317,7 +308,6 @@ export function buildToolGuide(): string {
   }
 
   return `<tool_guide>
-${lines.join('
-')}
+${lines.join('\n')}
 </tool_guide>`;
 }


### PR DESCRIPTION
## Fixes CI build errors introduced in #151 (UI/UX Audit)

**Build errors (11 from 4 root causes):**

### 1. Unterminated string literals (3 files)
Raw newlines inside string literals instead of \\n escape sequences:
- `src/graph/reactivePackerWrapper.ts` (L134-135)
- `src/context/TranscriptCompaction.ts` (L110-111)
- `src/context/PromptRouter.ts` (L136-137)

### 2. Conditional React Hook
- `src/components/ds/ExperimentalBadge.tsx` (L95): `useTheme()` called after early returns. Moved hook call before conditional returns per Rules of Hooks.

---

**Not addressed (non-blocking lint warnings):** 11 React Hook dependency array warnings across various components.